### PR TITLE
New features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.noodles.staffmodegui2</groupId>
     <artifactId>StaffModeGUI2</artifactId>
-    <version>1.3</version>
+    <version>1.3.1</version>
     <packaging>jar</packaging>
 
     <name>StaffModeGUI2</name>
@@ -63,6 +63,10 @@
             <id>FL-Releases</id>
             <url>http://repo.gamerking195.com/artifactory/FL-Releases</url>
         </repository>
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
 
     </repositories>
 
@@ -71,6 +75,12 @@
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
             <version>1.8.8-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.10.5</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/Inv/FlyInv.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/Inv/FlyInv.java
@@ -4,6 +4,7 @@ import net.noodles.staffmodegui2.staffmodegui2.Inv.InvItems.FlyInvItems;
 import net.noodles.staffmodegui2.staffmodegui2.StaffModeGUI2;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -70,8 +71,10 @@ public class FlyInv implements Listener {
             player.sendMessage(StaffModeGUI2.getPlugin().getConfig().getString("flyMenu.messageItemON").replace("&", "§"));
             player.closeInventory();
         } else if (event.getCurrentItem().isSimilar(FlyInvItems.FlyOFF())) {
-            player.setAllowFlight(false);
-            player.setFlying(false);
+            if (player.getGameMode() != GameMode.CREATIVE) {
+                player.setAllowFlight(false);
+                player.setFlying(false);
+            }
             player.sendMessage(StaffModeGUI2.getPlugin().getConfig().getString("flyMenu.messageItemOFF").replace("&", "§"));
             player.closeInventory();
         } else if (event.getCurrentItem().isSimilar(FlyInvItems.menuReturn())) {

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/StaffModeGUI2.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/StaffModeGUI2.java
@@ -6,6 +6,7 @@ import net.noodles.staffmodegui2.staffmodegui2.commands.StaffModeDev;
 import net.noodles.staffmodegui2.staffmodegui2.util.Logger;
 import net.noodles.staffmodegui2.staffmodegui2.util.MetricsLite;
 import net.noodles.staffmodegui2.staffmodegui2.util.Settings;
+import net.noodles.staffmodegui2.staffmodegui2.util.StaffModeGUIExpansion;
 import net.noodles.staffmodegui2.staffmodegui2.util.UpdateChecker.UpdateChecker;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
@@ -44,6 +45,11 @@ public final class StaffModeGUI2 extends JavaPlugin {
     @Override
     public void onEnable() {
         this.createConfig();
+
+        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null){
+            new StaffModeGUIExpansion(this).register();
+        }
+
         if (getConfig().getBoolean("SilentStart.Enabled")) {
             plugin = this;
             instance = this;

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/StaffModeGUI2.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/StaffModeGUI2.java
@@ -3,6 +3,7 @@ package net.noodles.staffmodegui2.staffmodegui2;
 import net.noodles.staffmodegui2.staffmodegui2.Inv.*;
 import net.noodles.staffmodegui2.staffmodegui2.commands.StaffModeCommand;
 import net.noodles.staffmodegui2.staffmodegui2.commands.StaffModeDev;
+import net.noodles.staffmodegui2.staffmodegui2.commands.StaffModeReload;
 import net.noodles.staffmodegui2.staffmodegui2.util.Logger;
 import net.noodles.staffmodegui2.staffmodegui2.util.MetricsLite;
 import net.noodles.staffmodegui2.staffmodegui2.util.Settings;
@@ -61,6 +62,7 @@ public final class StaffModeGUI2 extends JavaPlugin {
 
             new StaffModeCommand();
             new StaffModeDev();
+            new StaffModeReload();
 
             this.mainInv = new MainInv(this);
             this.whitelistInv = new WhitelistInv(this);
@@ -119,6 +121,7 @@ public final class StaffModeGUI2 extends JavaPlugin {
             Logger.log(Logger.LogLevel.INFO, "Registering Commands...");
             new StaffModeCommand();
             new StaffModeDev();
+            new StaffModeReload();
             Logger.log(Logger.LogLevel.INFO, "Commands Registered!");
             Logger.log(Logger.LogLevel.INFO, "Loading Inventory's...");
             this.mainInv = new MainInv(this);

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/commands/StaffModeCommand.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/commands/StaffModeCommand.java
@@ -39,7 +39,7 @@ public class StaffModeCommand implements CommandExecutor {
                     p.sendMessage(ChatColor.translateAlternateColorCodes('&', staffmodegui2.getConfig().getString("defaultMessage.noPermission").replace("&", "§")));
                     return false;
                 }
-                p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&eThis has been moved to &f/staffmodereload"));
+                p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&eThis command has been moved to &f/staffmodereload"));
                 return true;
             } else if (args[0].equalsIgnoreCase("about")) {
                 if (!p.hasPermission("staffmodegui.about")) {

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/commands/StaffModeCommand.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/commands/StaffModeCommand.java
@@ -39,8 +39,7 @@ public class StaffModeCommand implements CommandExecutor {
                     p.sendMessage(ChatColor.translateAlternateColorCodes('&', staffmodegui2.getConfig().getString("defaultMessage.noPermission").replace("&", "§")));
                     return false;
                 }
-                staffmodegui2.reloadConfig();
-                p.sendMessage(ChatColor.translateAlternateColorCodes('&', staffmodegui2.getConfig().getString("defaultMessage.reloadMessage").replace("&", "§")));
+                p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&eThis has been moved to &f/staffmodereload"));
                 return true;
             } else if (args[0].equalsIgnoreCase("about")) {
                 if (!p.hasPermission("staffmodegui.about")) {
@@ -69,7 +68,7 @@ public class StaffModeCommand implements CommandExecutor {
                 p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&c/staffmode help &7- &fThis help page"));
                 p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&c/staffmode about &7- &fThe about page"));
                 p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&c/staffmode update &7- &fChecks for an update on SpigotMC"));
-                p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&c/staffmode reload &7- &fReloads the config file"));
+                p.sendMessage(ChatColor.translateAlternateColorCodes('&', "&c/staffmodereload &7- &fReloads the config file"));
                 p.sendMessage("");
                 p.sendMessage(ChatColor.GRAY + "****************************************************");
                 return true;

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/commands/StaffModeReload.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/commands/StaffModeReload.java
@@ -1,0 +1,28 @@
+package net.noodles.staffmodegui2.staffmodegui2.commands;
+
+import net.noodles.staffmodegui2.staffmodegui2.StaffModeGUI2;
+import org.bukkit.ChatColor;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+
+public class StaffModeReload implements CommandExecutor {
+
+    private StaffModeGUI2 staffmodegui2;
+
+    public StaffModeReload() {
+        staffmodegui2 = StaffModeGUI2.getInstance();
+        staffmodegui2.getCommand("staffmodereload").setExecutor(this);
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command cmd, String cmdLabel, String[] args) {
+        if (!sender.hasPermission("staffmodegui.reload")) {
+            sender.sendMessage(ChatColor.translateAlternateColorCodes('&', staffmodegui2.getConfig().getString("defaultMessage.noPermission").replace("&", "§")));
+            return false;
+        }
+        staffmodegui2.reloadConfig();
+        sender.sendMessage(ChatColor.translateAlternateColorCodes('&', staffmodegui2.getConfig().getString("defaultMessage.reloadMessage").replace("&", "§")));
+        return false;
+    }
+}

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/util/Settings.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/util/Settings.java
@@ -1,6 +1,11 @@
 package net.noodles.staffmodegui2.staffmodegui2.util;
 
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class Settings {
 
@@ -11,8 +16,20 @@ public class Settings {
     public static String DEV_MESSAGE3 = ChatColor.GRAY + "https://goo.gl/87ZgJz";
     public static String PLUGIN_URL = "https://spigotmc.org/resources/60960";
     public static String SUPPORT_DISCORD_URL = "https://bghddevelopment.com/discord";
-    public static String VERSION = "1.3";
+    public static String VERSION = "1.3.1";
     public static String WIKI = "https://wiki.bghddevelopment.com";
     public static String NAME = "StaffModeGUI2";
+
+    public static List<Player> getOnlineStaff() {
+        List<Player> players = new ArrayList<>();
+
+        for (Player player : Bukkit.getServer().getOnlinePlayers()) {
+            if (player.hasPermission("staffmodegui.staff")) {
+                players.add(player);
+            }
+        }
+
+        return players;
+    }
 
 }

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/util/Settings.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/util/Settings.java
@@ -33,5 +33,3 @@ public class Settings {
     }
 
 }
-
-}

--- a/src/main/java/net/noodles/staffmodegui2/staffmodegui2/util/StaffModeGUIExpansion.java
+++ b/src/main/java/net/noodles/staffmodegui2/staffmodegui2/util/StaffModeGUIExpansion.java
@@ -1,0 +1,53 @@
+package net.noodles.staffmodegui2.staffmodegui2.util;
+
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import net.noodles.staffmodegui2.staffmodegui2.StaffModeGUI2;
+import org.bukkit.entity.Player;
+
+public class StaffModeGUIExpansion extends PlaceholderExpansion {
+
+    private StaffModeGUI2 plugin;
+
+    public StaffModeGUIExpansion(StaffModeGUI2 plugin){
+        this.plugin = plugin;
+    }
+
+    @Override
+    public boolean persist(){
+        return true;
+    }
+
+    @Override
+    public boolean canRegister(){
+        return true;
+    }
+
+    @Override
+    public String getAuthor(){
+        return plugin.getDescription().getAuthors().toString();
+    }
+
+    @Override
+    public String getIdentifier(){
+        return "staffmodegui";
+    }
+
+    @Override
+    public String getVersion(){
+        return plugin.getDescription().getVersion();
+    }
+
+    @Override
+    public String onPlaceholderRequest(Player player, String identifier){
+
+        if(player == null){
+            return "";
+        }
+
+        if(identifier.equals("staffonline")){
+            return String.valueOf(Settings.getOnlineStaff().size());
+        }
+
+        return null;
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,5 +1,5 @@
 #=======================================================
-configVersion: 1.3
+configVersion: 1.3.1
 # DO NOT CHANGE PLEASE.
 #=======================================================
 # Permission Needed: staffmodegui.update

--- a/src/main/resources/permissions.yml
+++ b/src/main/resources/permissions.yml
@@ -14,6 +14,9 @@ permissions:
   staffmodegui.reload:
     description: Gives you access to /staffmode reload
     default: op
+  staffmodegui.staff:
+    description: Get all online staff members with this permission
+    default: op
   staffmodegui.whitelistmenu:
     description: Gives you access to the Whitelist Menu
     default: op

--- a/src/main/resources/permissions.yml
+++ b/src/main/resources/permissions.yml
@@ -12,7 +12,7 @@ permissions:
     description: Gives you access to see update notifications on join also gives you access to /staffmode update
     default: op
   staffmodegui.reload:
-    description: Gives you access to /staffmode reload
+    description: Gives you access to /staffmodereload
     default: op
   staffmodegui.staff:
     description: Get all online staff members with this permission

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -11,3 +11,6 @@ commands:
   staffmode:
     description: StaffMode command
     aliases: [sm, smgui]
+  staffmodereload:
+    description: StaffModeReload command
+    aliases: smreload


### PR DESCRIPTION
Tested on 1.8-1.16

Changes:
- Added [StaffModeGUI2 Placeholders](https://feedback.bghddevelopment.com/d/394-staffmodegui2-add-placeholders) from the Feedback site (The placeholder is %staffmodegui_staffonline% permission is staffmodegui.staff)
- Moved /staffmode reload to /staffmodereload for console support
- Added a check to the Fly menu, if you are in Creative mode it will not disable your flight

This doesn't need to be released right now it can be released next week